### PR TITLE
nginxのログを出す

### DIFF
--- a/isucon7-qualifier/docker-compose.yml
+++ b/isucon7-qualifier/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       - app
     ports:
       - "80:80"
+    volumes:
+      - ./log/nginx:/var/log/nginx
   app:
     build:
       #context: ./docker/app/golang

--- a/isucon7-qualifier/docker-compose.yml
+++ b/isucon7-qualifier/docker-compose.yml
@@ -61,6 +61,8 @@ services:
       #MYSQL_DATABASE: isubata
       #MYSQL_USER: isucon
       #MYSQL_PASSWORD: isucon
+    volumes:
+      - ./log/mysql:/var/log/mysql
 networks:
   frontend:
   backend:

--- a/isucon7-qualifier/docker/db/Dockerfile
+++ b/isucon7-qualifier/docker/db/Dockerfile
@@ -13,5 +13,6 @@ ENV MYSQL_ALLOW_EMPTY_PASSWORD=yes MYSQL_DATABASE=isubata MYSQL_USER=isucon MYSQ
 
 COPY --from=build-dev /home/isucon/isubata/db/isubata.sql /docker-entrypoint-initdb.d/01_isubata.sql
 COPY --from=build-dev /home/isucon/isubata/bench/isucon7q-initial-dataset.sql.gz /docker-entrypoint-initdb.d/isucon7q-initial-dataset.sql.gz
+COPY ./docker/db/isucon.conf /etc/my.cnf
 
 CMD ["--character-set-server=utf8mb4"]

--- a/isucon7-qualifier/docker/db/isucon.conf
+++ b/isucon7-qualifier/docker/db/isucon.conf
@@ -1,0 +1,4 @@
+[mysqld]
+slow_query_log      = 1
+slow_query_log_file = /var/log/mysql/mysql-slow.log
+long_query_time     = 0

--- a/isucon7-qualifier/docker/web/isucon.conf
+++ b/isucon7-qualifier/docker/web/isucon.conf
@@ -1,7 +1,20 @@
+log_format json '{"time":"$time_iso8601",'
+                 '"host":"$remote_addr",'
+                 '"port":$remote_port,'
+                 '"method":"$request_method",'
+                 '"uri":"$request_uri",'
+                 '"status":"$status",'
+                 '"body_bytes":$body_bytes_sent,'
+                 '"referer":"$http_referer",'
+                 '"ua":"$http_user_agent",'
+                 '"request_time":"$request_time",'
+                 '"response_time":"$upstream_response_time"}';
+
 server {
         listen 80 default_server;
         listen [::]:80 default_server;
         server_name isubata.example.com;
+        access_log /var/log/nginx/access.log json;
 
         client_max_body_size 20M;
 

--- a/isucon7-qualifier/lotate.sh
+++ b/isucon7-qualifier/lotate.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# 実行時点の日時を YYYYMMDD-HHMMSS 形式で付与したファイル名にローテートする 
+docker-compose exec -it web mv /var/log/nginx/access.log /var/log/nginx/access.`date +%Y%m%d-%H%M%S`.log
+# nginxにログファイルを開き直すシグナルを送信する
+docker-compose exec -it web nginx -s reopen


### PR DESCRIPTION
<img width="925" alt="スクリーンショット 2022-06-26 17 31 41" src="https://user-images.githubusercontent.com/75765648/175806283-adea691f-32c9-449c-868f-55b7fa334513.png">

```
cd docker-isucon/isucon7-qualifier
alp json  --sort sum -r  -m "posts/[0-9]+, /@\w+, /image/\d+"  -o count,method,uri,min,avg,max,sum  < log/nginx/access.log
```
を実行すると良い感じにログが見れる
